### PR TITLE
Change attributes of datalims to tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Security in case of vulnerabilities.
 
 ## [Unreleased]
 
+### Changed
+
+- Attributes of {class}`pymech.exadata.datalims` are now immutable tuples.
+
 ## [1.4.1] - 2021-05-07
 
 Backwards compatible release with a lot of housekeeping and some usability

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -45,9 +45,9 @@ def test_readnek():
     Dimensions:    3
     Precision:     4 bytes
     Mesh limits:
-      * x:         [0.         6.28318548]
-      * y:         [-1.  1.]
-      * z:         [0.         3.14159274]
+      * x:         (0.0, 6.2831854820251465)
+      * y:         (-1.0, 1.0)
+      * z:         (0.0, 3.1415927410125732)
     Time:
       * time:      0.2
       * istep:     10

--- a/tests/test_datalims.py
+++ b/tests/test_datalims.py
@@ -1,0 +1,37 @@
+import pytest
+from numpy import testing as npt
+
+
+def test_lims():
+    from pymech.neksuite import readnek
+
+    fld = readnek("tests/nek/channel3D_0.f00001")
+
+    with pytest.raises(AttributeError):
+        fld.lims = ()
+
+    with pytest.raises(AttributeError):
+        fld.lims.pos = ((0, 3.14), (0, 1), (-1, 1))
+
+    with pytest.raises(TypeError):
+        fld.lims.pos[0, 1] = 3.14
+
+    npt.assert_array_equal(
+        fld.lims.pos,
+        (
+            (0.0, 6.2831854820251465),
+            (-1.0, 1.0),
+            (0.0, 3.1415927410125732),
+        ),
+    )
+    npt.assert_array_equal(
+        fld.lims.vel,
+        (
+            (-0.0001499584031989798, 1.2596282958984375),
+            (-0.024550313130021095, 0.021655898541212082),
+            (-0.022412149235606194, 0.020889850333333015),
+        ),
+    )
+    npt.assert_array_equal(fld.lims.pres, ((-0.2145293802022934, 0.2344336062669754),))
+    npt.assert_array_equal(fld.lims.temp, ())
+    npt.assert_array_equal(fld.lims.scal, ())


### PR DESCRIPTION
Advantage: Fails quickly, educates user not to manually set lims

Avoids issues like #33 to some extent