### PR TITLE
Avoid logging.basicConfig

### DIFF
--- a/pymech/log.py
+++ b/pymech/log.py
@@ -27,7 +27,10 @@ try:
     logger.addHandler(handler)
 except ImportError:
     # No color available, use default config
-    logging.basicConfig(format="%(levelname)s: %(message)s")
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
     logger.info("Disabling color, you really want to install colorlog.")
 
 

--- a/pymech/log.py
+++ b/pymech/log.py
@@ -15,6 +15,7 @@ For coloured logging::
 """
 import os
 import logging
+from typing import Union
 
 logger = logging.getLogger("pymech")
 
@@ -23,16 +24,15 @@ try:
     # Set a nice colored output
     from rich.logging import RichHandler
 
-    handler = RichHandler()
-    logger.addHandler(handler)
+    handler: Union[RichHandler, logging.StreamHandler] = RichHandler()
 except ImportError:
     # No color available, use default config
     handler = logging.StreamHandler()
     formatter = logging.Formatter("%(levelname)s: %(message)s")
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
     logger.info("Disabling coloured logs; if needed you should `pip install rich`.")
 
+logger.addHandler(handler)
 
 if bool(os.getenv("PYMECH_DEBUG")):
     logger.setLevel(logging.DEBUG)

--- a/pymech/log.py
+++ b/pymech/log.py
@@ -31,7 +31,7 @@ except ImportError:
     formatter = logging.Formatter("%(levelname)s: %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    logger.info("Disabling color, you really want to install colorlog.")
+    logger.info("Disabling coloured logs; if needed you should `pip install rich`.")
 
 
 if bool(os.getenv("PYMECH_DEBUG")):


### PR DESCRIPTION
Fixes #66 (and https://github.com/snek5000/snek5000/issues/38)

`logging.basicConfig` should be used only in scripts because it affects the root logger, which can break other loggers.