### PR TITLE
Support unstructured grid (Issue #125)

### DIFF
--- a/src/pymech/dataset.py
+++ b/src/pymech/dataset.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
+import uxarray as uxr
 from xarray.core.utils import Frozen
 
 from .neksuite import readnek
@@ -98,6 +99,53 @@ def _open_nek_dataset(path, drop_variables=None):
 
     return ds
 
+def extract_elem_data(elem_array):
+    # Use lists to accumulate data
+    x_list, y_list, z_list = [], [], []
+    ux_list, uy_list, uz_list, p_list = [], [], [], []
+
+    # Loop through the elements in the array
+    for elem in elem_array:
+        # Append data to respective lists
+        x_list.append(np.ravel(elem.pos[0]))
+        y_list.append(np.ravel(elem.pos[1]))
+        z_list.append(np.ravel(elem.pos[2]))
+        
+        ux_list.append(np.ravel(elem.vel[0]))
+        uy_list.append(np.ravel(elem.vel[1]))
+        uz_list.append(np.ravel(elem.vel[2]))
+        
+        p_list.append(np.ravel(elem.pres))
+
+    # Convert lists to NumPy arrays after the loop
+    x = np.concatenate(x_list)
+    y = np.concatenate(y_list)
+    z = np.concatenate(z_list)
+    ux = np.concatenate(ux_list)
+    uy = np.concatenate(uy_list)
+    uz = np.concatenate(uz_list)
+    p = np.concatenate(p_list)
+
+    # Create an xarray dataset
+    data = xr.Dataset(
+        {
+            "ux": (["points"], ux),
+            "uy": (["points"], uy),
+            "uz": (["points"], uz),  # Correctly assign uz
+            "p": (["points"], p)     # Correctly assign p
+        },
+        coords={
+            "x": (["points"], x),
+            "y": (["points"], y),
+            "z": (["points"], z),
+        }
+    )
+
+    # Wrap the xarray dataset in a uxarray grid (optional)
+    ux_ds = uxr.Grid.from_dataset(data)
+
+    return ux_ds
+
 
 class PymechXarrayBackend(xr.backends.BackendEntrypoint):
     def guess_can_open(self, filename_or_obj):
@@ -184,3 +232,39 @@ class _NekDataStore(xr.backends.common.AbstractDataStore):
             )
 
         return Frozen(data_vars)
+
+
+def open_unstruc_dataset(path):
+    
+    # Proposed Methodology
+    # Step 1: Use readnek to import the data
+    # Step 2: Create an array of nodes, elements, and fields
+    # Step 3: Create a grid and xarray dataset from the data array
+    # Step 4: Create a uxarray dataset and return it
+
+    field = readnek(path)
+    if isinstance(field, int):
+        raise OSError(f"Failed to load {path}")
+
+    elements = field.elem
+    
+    # Method 1 : adapt the existing method used for xarray
+
+    #elem_stores = [_NekDataStore(elem) for elem in elements]
+    #
+    # try:
+    #     elem_dsets = [
+    #         uxr.UxDataset.load_store(store).set_coords(store.axes) for store in elem_stores
+    #     ]
+    # except Exception as error:
+    #     print("uxarray failure")
+    #     print(error)
+    #     print(elem_stores[0].axes)
+
+    # Method 2 : manually create array of x, y, z and variables and use it to 
+    # make a uxarray dataset
+    ds = extract_elem_data(elements)
+
+
+
+    


### PR DESCRIPTION
Hey !
I am looked into `uxarray` and attempted two methods to include support for unstructured grids. The fundamental working of both the methods is same.

**Proposed Methodology**
- Step 1: Use readnek to import the data
- Step 2: Create an array of nodes, elements, and fields
- Step 3: Create a grid and xarray dataset from the data array
- Step 4: Create a uxarray dataset and return it.

**Method 1**
Extend the current `xarray` method to `uxarray` as `uxarray` also supports the creation of dataset through `load_store()`. But unfortunately, it doesn't work. I get the following error.

```
conflicting sizes for dimension 'y': length 6 on 'xmesh' and length 36 on {'x': 'x', 'y': 'y', 'z': 'z'}.
``` 

**Method 2**
It is manual method to extract data from elements and store them as numpy arrays, use them to form a `xarray` dataset. I am able to make an `xarray` dataset which can be used for most post-processing stuff like plotting, POD calculations, etc. It lacks the element connectivity data, so is it required ? If not, this method can be used to handle structured and unstructured arrays both. 

`extract_elem_data` is the implementation of Method 2.  We may not require the use of `uxarray`. 

A `uxarray` Grid can be constructed from the coordinates and connectivity data through [uxarray.Grid.from_dataset](https://uxarray.readthedocs.io/en/latest/generated/uxarray.Grid.from_dataset.html#uxarray.Grid.from_dataset) and used with the available values to create a uxarray dataset using [uxarray.UxDataset](https://uxarray.readthedocs.io/en/latest/internal_api/generated/uxarray.UxDataset.html#uxarray.UxDataset). Can someone help me in extracting the connectivity, so I can attempt creation of an `uxarray` dataset.

Thanks !
Gaurav 
 