### PR TITLE
set sensible defaults for all variables in `HexaData`

### DIFF
--- a/src/pymech/core.py
+++ b/src/pymech/core.py
@@ -238,7 +238,7 @@ class HexaData:
         self.nbc = nbc
         self.var = var
         self.lr1 = lr1
-        self.time = 0.
+        self.time = 0.0
         self.istep = 0
         self.wdsz = 8
         self.endian = sys.byteorder

--- a/src/pymech/core.py
+++ b/src/pymech/core.py
@@ -2,6 +2,7 @@
 
 import copy
 import itertools
+import sys
 from functools import partial, reduce
 from itertools import product
 from textwrap import dedent, indent
@@ -233,14 +234,14 @@ class HexaData:
     def __init__(self, ndim, nel, lr1, var, nbc=0, dtype="float64"):
         self.ndim = ndim
         self.nel = nel
-        self.ncurv = []
+        self.ncurv = 0
         self.nbc = nbc
         self.var = var
         self.lr1 = lr1
-        self.time = []
-        self.istep = []
-        self.wdsz = []
-        self.endian = []
+        self.time = 0.
+        self.istep = 0
+        self.wdsz = 8
+        self.endian = sys.byteorder
         if isinstance(dtype, type):
             # For example np.float64 -> "float64"
             dtype = dtype.__name__

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -672,7 +672,7 @@ def test_readdns(test_data_dir):
     field = ss.readdns(fname)
 
     assert field.endian == "little"
-    assert field.istep == []
+    assert field.istep == 0
     assert field.lr1 == [48, 65, 48]
     assert field.ndim == 3
     assert field.nel == 1


### PR DESCRIPTION
Fixes #135.
Some variables were initialised to `[]`, which can cause crashes if passed to functions that expect a meaningful value. The endianness is now also initialised to the system default, which removes the warnings about default endianness.